### PR TITLE
フォークしたリポジトリからのPull Requestを自動的にクローズするGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/close-pr-from-forked-repo.yml
+++ b/.github/workflows/close-pr-from-forked-repo.yml
@@ -1,0 +1,37 @@
+name: Close PR from forked repo
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close-fork-pr:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: クローズ理由のコメントを追加
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'このリポジトリでは、フォークしたリポジトリからのPull requestは受け付けておりません。ご理解のほどよろしくお願いいたします。\n\nWe do not accept Pull requests from forked repositories. Thank you for your understanding.'
+            });
+            
+      - name: PR をクローズ
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

フォークしたリポジトリからPRを受け取った際、コメントを残したうえで自動的にクローズするようにします。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://github.com/AlesInfiny/ai-education/issues/46>

<!-- I want to review in Japanese. -->